### PR TITLE
remove overriding url for member profile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dev_orbit (0.1.3)
+    dev_orbit (0.2.0)
       actionview (~> 6.1)
       activesupport (~> 6.1)
       http (~> 4.4)
@@ -60,15 +60,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     minitest (5.14.4)
-    nokogiri (1.11.5-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.11.5-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.11.5-x86_64-linux)
-      racc (~> 1.4)
-    nokogiri (1.11.3-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.11.3-x86_64-linux)
+    nokogiri (1.11.3-arm64-darwin)
       racc (~> 1.4)
     orbit_activities (0.1.0)
       http (~> 4.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     ast (2.4.2)
     builder (3.2.4)
     byebug (11.1.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -38,7 +38,7 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.10.0)
-    ffi (1.15.0)
+    ffi (1.15.1)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -48,7 +48,7 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       http-parser (~> 1.2.0)
-    http-cookie (1.0.3)
+    http-cookie (1.0.4)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     http-parser (1.2.3)
@@ -56,11 +56,11 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
-    loofah (2.9.1)
+    loofah (2.10.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     minitest (5.14.4)
-    nokogiri (1.11.3-arm64-darwin)
+    nokogiri (1.11.7-arm64-darwin)
       racc (~> 1.4)
     orbit_activities (0.1.0)
       http (~> 4.4)
@@ -68,7 +68,7 @@ GEM
       rake (~> 13.0)
       zeitwerk (~> 2.4)
     parallel (1.20.1)
-    parser (3.0.0.0)
+    parser (3.0.1.1)
       ast (~> 2.4.1)
     public_suffix (4.0.6)
     racc (1.5.2)
@@ -94,17 +94,17 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.11.0)
+    rubocop (1.16.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.2.0, < 2.0)
+      rubocop-ast (>= 1.7.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.4.1)
-      parser (>= 2.7.1.5)
+    rubocop-ast (1.7.0)
+      parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
     thor (1.1.0)
     tzinfo (2.0.4)
@@ -113,7 +113,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (2.0.0)
-    webmock (3.12.1)
+    webmock (3.13.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -121,8 +121,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
-  x86_64-darwin-19
-  x86_64-linux
 
 DEPENDENCIES
   byebug

--- a/lib/dev_orbit/dev.rb
+++ b/lib/dev_orbit/dev.rb
@@ -19,6 +19,8 @@ module DevOrbit
       articles = get_articles(type: type)
 
       articles.each do |article|
+        require 'byebug'
+        #byebug
         comments = get_article_comments(article["id"])
 
         next if comments.nil? || comments.empty?

--- a/lib/dev_orbit/dev.rb
+++ b/lib/dev_orbit/dev.rb
@@ -19,8 +19,6 @@ module DevOrbit
       articles = get_articles(type: type)
 
       articles.each do |article|
-        require 'byebug'
-        #byebug
         comments = get_article_comments(article["id"])
 
         next if comments.nil? || comments.empty?

--- a/lib/dev_orbit/interactions/follower.rb
+++ b/lib/dev_orbit/interactions/follower.rb
@@ -43,8 +43,7 @@ module DevOrbit
         {
           member: {
             name: @name.include?("_") ? @name.split("_").map(&:capitalize).join(" ") : @name,
-            devto: @username,
-            url: "https://dev.to#{@url}"
+            devto: @username
           }
         }
       end

--- a/spec/interactions/follower_spec.rb
+++ b/spec/interactions/follower_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe DevOrbit::Interactions::Follower do
       stub_request(:post, "https://app.orbit.love/api/v1/1234/members")
         .with(
           headers: { 'Authorization' => "Bearer 12345", 'Content-Type' => 'application/json' },
-          body: "{\"member\":{\"name\":\"Ben Greenberg\",\"devto\":\"bengreenberg\",\"url\":\"https://dev.to/bengreenberg\"}}"
+          body: "{\"member\":{\"name\":\"Ben Greenberg\",\"devto\":\"bengreenberg\"}}"
         ).to_return(
           status: 200,
           body: {


### PR DESCRIPTION
The new follower method adds the DEV URL as the member main profile link, which is not the expected behavior. The expected behavior is not to override a link that could have been manually set by the administrator of the workspace for a member profile. This PR removes it from the member object. The DEV profile link will still be added as an identity.