### PR TITLE
Dynamic import for DEV comments + tests + README update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,25 @@
 PATH
   remote: .
   specs:
-    dev_orbit (0.2.0)
+    dev_orbit (0.3.0)
       actionview (~> 6.1)
       activesupport (~> 6.1)
       http (~> 4.4)
       json (~> 2.5)
-      orbit_activities (~> 0.1)
+      orbit_activities (~> 0.2)
       thor (~> 1.1)
       zeitwerk (~> 2.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionview (6.1.3.2)
-      activesupport (= 6.1.3.2)
+    actionview (6.1.4)
+      activesupport (= 6.1.4)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activesupport (6.1.3.2)
+    activesupport (6.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -38,7 +38,7 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.10.0)
-    ffi (1.15.1)
+    ffi (1.15.3)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -62,7 +62,7 @@ GEM
     minitest (5.14.4)
     nokogiri (1.11.7-arm64-darwin)
       racc (~> 1.4)
-    orbit_activities (0.1.0)
+    orbit_activities (0.2.2)
       http (~> 4.4)
       json (~> 2.5)
       rake (~> 13.0)
@@ -94,7 +94,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.16.0)
+    rubocop (1.17.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ client = DevOrbit::Client.new(
 )
 ```
 
+### Performing a Historical Import
+
+By default, the integration will only import comments that are newer than the newest DEV comment in your Orbit workspace. You may want to perform a one-time historical import to fetch all your previous DEV comments and bring them into your Orbit workspace. To do so, instantiate your `client` with the `historical_import` flag:
+
+```ruby
+client = DevOrbit::Client.new(
+  historical_import: true
+)
+```
 ### Post New DEV Comments from a DEV User to Orbit Workspace
 
 You can use the gem to get new DEV comments on your DEV user by invoking the `#comments` method on your `client` instance:
@@ -73,7 +82,6 @@ client.organization_comments
 ```
 
 This method will fetch all your organization articles from DEV, gather their respective comments, filter them for anything within the past day, and then send them to your Orbit workspace via the Orbit API.
-
 
 ### Post New DEV Followers to Orbit Workspace
 
@@ -106,6 +114,7 @@ $ ORBIT_API_KEY='...' ORBIT_WORKSPACE='...' DEV_API_KEY='...' DEV_USERNAME='...'
 ```bash
 $ ORBIT_API_KEY='...' ORBIT_WORKSPACE='...' DEV_API_KEY='...' DEV_ORGANIZATION='...' bundle exec dev_orbit --check-organization-comments
 ```
+**Add the `--historical-import` flag to your CLI command to perform a historical import of all your DEV comments using the CLI.**
 
 ## Contributing
 

--- a/bin/dev_orbit
+++ b/bin/dev_orbit
@@ -4,6 +4,7 @@ require 'optparse'
 check_comments = false
 check_followers = false
 check_org_comments = false
+historical_import = false
 
 options = {}
 choices = OptionParser.new do |opts|
@@ -21,6 +22,9 @@ choices = OptionParser.new do |opts|
   opts.on("--check-organization-comments", "Check for new DEV comments for an organization") do
     check_org_comments = true
   end
+  opts.on("--historical-import", "Performa historical import of all new DEV comments") do
+    historical_import = true
+  end
 end.parse!
 
 $LOAD_PATH.unshift(File.expand_path('../lib/dev_orbit', __dir__))
@@ -33,6 +37,7 @@ require_relative '../scripts/check_org_comments'
 if check_comments
   puts "Checking for new DEV comments within the past day and posting them to your Orbit workspace..."
   ARGV[0] = 'render'
+  ARGV[1] = historical_import
   DevOrbit::Scripts::CheckComments.start(ARGV)
 end
 
@@ -45,5 +50,6 @@ end
 if check_org_comments
   puts "Checking for new DEV organization comments and posting them to your Orbit workspace..."
   ARGV[0] = 'render'
+  ARGV[1] = historical_import
   DevOrbit::Scripts::CheckOrgComments.start(ARGV)
 end

--- a/dev_orbit.gemspec
+++ b/dev_orbit.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json", "~> 2.5"
   spec.add_dependency "zeitwerk", "~> 2.4"
   spec.add_dependency "thor", "~> 1.1"
-  spec.add_dependency "orbit_activities", "~> 0.1"
+  spec.add_dependency "orbit_activities", "~> 0.2"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "webmock", "~> 3.12"
 

--- a/lib/dev_orbit/client.rb
+++ b/lib/dev_orbit/client.rb
@@ -22,13 +22,17 @@
 # @option params [String] :orbit_api_key
 #   The API key for the Orbit API
 #
+# @option params [Boolean] :historical_import
+#   Perform a historical import on all DEV comments
+#   Boolean, default to false
+#
 # @param [Hash] params
 #
 # @return [DevOrbit::Client]
 #
 module DevOrbit
   class Client
-    attr_accessor :dev_username, :dev_api_key, :dev_organization, :orbit_workspace, :orbit_api_key
+    attr_accessor :dev_username, :dev_api_key, :dev_organization, :orbit_workspace, :orbit_api_key, :historical_import
 
     def initialize(params = {})
       @orbit_api_key = params.fetch(:orbit_api_key, ENV["ORBIT_API_KEY"])
@@ -36,6 +40,7 @@ module DevOrbit
       @dev_api_key = params.fetch(:dev_api_key, ENV["DEV_API_KEY"])
       @dev_username = params.fetch(:dev_username, ENV["DEV_USERNAME"])
       @dev_organization = params.fetch(:dev_organization, ENV["DEV_ORGANIZATION"])
+      @historical_import = params.fetch(:historical_import, false)
     end
 
     # Fetch new comments from DEV and post them to the Orbit workspace
@@ -44,7 +49,8 @@ module DevOrbit
         api_key: @dev_api_key,
         username: @dev_username,
         workspace_id: @orbit_workspace,
-        orbit_api_key: @orbit_api_key
+        orbit_api_key: @orbit_api_key,
+        historical_import: @historical_import
       ).process_comments(type: type)
     end
 

--- a/lib/dev_orbit/dev.rb
+++ b/lib/dev_orbit/dev.rb
@@ -13,6 +13,7 @@ module DevOrbit
       @api_key = params.fetch(:api_key, ENV["DEV_API_KEY"])
       @workspace_id = params.fetch(:workspace_id, ENV["ORBIT_WORKSPACE_ID"])
       @orbit_api_key = params.fetch(:orbit_api_key, ENV["ORBIT_API_KEY"])
+      @historical_import = params.fetch(:historical_import, false)
     end
 
     def process_comments(type:)
@@ -23,7 +24,7 @@ module DevOrbit
 
         next if comments.nil? || comments.empty?
 
-        DevOrbit::Orbit.call(
+        return DevOrbit::Orbit.new(
           type: "comments",
           data: {
             comments: comments,
@@ -31,8 +32,9 @@ module DevOrbit
             url: article["url"]
           },
           workspace_id: @workspace_id,
-          api_key: @orbit_api_key
-        )
+          api_key: @orbit_api_key,
+          historical_import: @historical_import
+        ).call
       end
     end
 
@@ -42,14 +44,15 @@ module DevOrbit
       followers.each do |follower|
         next if follower.nil? || follower.empty?
 
-        DevOrbit::Orbit.call(
+        DevOrbit::Orbit.new(
           type: "followers",
           data: {
             follower: follower
           },
           workspace_id: @workspace_id,
-          api_key: @orbit_api_key
-        )
+          api_key: @orbit_api_key,
+          historical_import: @historical_import
+        ).call
       end
     end
 
@@ -100,13 +103,7 @@ module DevOrbit
 
       return if comments.nil? || comments.empty?
 
-      filter_comments(comments)
-    end
-
-    def filter_comments(comments)
-      comments.select do |comment|
-        comment["created_at"] <= 1.day.ago
-      end
+      comments
     end
   end
 end

--- a/lib/dev_orbit/orbit.rb
+++ b/lib/dev_orbit/orbit.rb
@@ -2,31 +2,80 @@
 
 require "net/http"
 require "json"
+require "active_support/time"
 
 module DevOrbit
   class Orbit
-    def self.call(type:, data:, workspace_id:, api_key:)
-      if type == "comments"
-        data[:comments].each do |comment|
+    def initialize(type:, data:, workspace_id:, api_key:, historical_import: false)
+      @type = type
+      @data = data
+      @workspace_id = workspace_id
+      @api_key = api_key
+      @historical_import = historical_import
+      @last_orbit_activity_timestamp = last_orbit_activity_timestamp(type)
+    end
+    
+    def call
+      if @type == "comments"
+        times = 0
+        
+        @data[:comments].each do |comment|
+          unless @historical_import && @last_orbit_activity_timestamp
+            puts "inside first condition"
+            next if comment["created_at"] || comment[:created_at] < @last_orbit_activity_timestamp unless @last_orbit_activity_timestamp.nil? 
+          end
+
+          if @last_orbit_activity_timestamp && @historical_import == false
+            puts "inside second condition"
+            next if comment["created_at"] || comment[:created_at] < @last_orbit_activity_timestamp
+          end
+
+          times += 1
+
           DevOrbit::Interactions::Comment.new(
-            article_title: data.transform_keys(&:to_sym)[:title],
+            article_title: @data.transform_keys(&:to_sym)[:title],
             comment: comment.transform_keys(&:to_sym),
-            url: data[:url],
-            workspace_id: workspace_id,
-            api_key: api_key
+            url: @data[:url],
+            workspace_id: @workspace_id,
+            api_key: @api_key
           )
         end
+
+        output = "Sent #{times} new DEV comments to your Orbit workspace"
+        
+        puts output
+        return output
       end
 
-      if type == "followers"
+      if @type == "followers"
         DevOrbit::Interactions::Follower.new(
-          id: data[:follower]["id"],
-          name: data[:follower]["name"],
-          username: data[:follower]["username"],
-          url: data[:follower]["path"],
-          workspace_id: workspace_id,
-          api_key: api_key
+          id: @data[:follower]["id"],
+          name: @data[:follower]["name"],
+          username: @data[:follower]["username"],
+          url: @data[:follower]["path"],
+          workspace_id: @workspace_id,
+          api_key: @api_key
         )
+      end
+    end
+
+    def last_orbit_activity_timestamp(type)
+      @last_orbit_activity_timestamp ||= begin
+        if type == "comments"
+          activity_type = "custom:dev:comment"
+        end
+
+        if type == "followers"
+          return nil
+        end
+
+        OrbitActivities::Request.new(
+          api_key: @api_key,
+          workspace_id: @workspace_id,
+          user_agent: "community-ruby-dev-orbit/#{DevOrbit::VERSION}",
+          action: "latest_activity_timestamp",
+          filters: { activity_type: activity_type }
+        ).response
       end
     end
   end

--- a/scripts/check_comments.rb
+++ b/scripts/check_comments.rb
@@ -8,8 +8,8 @@ module DevOrbit
   module Scripts
     class CheckComments < Thor
       desc "render", "check for new DEV comments and push them to Orbit"
-      def render
-        client = DevOrbit::Client.new
+      def render(*params)
+        client = DevOrbit::Client.new(historical_import: params[0])
         client.comments
       end
     end

--- a/scripts/check_org_comments.rb
+++ b/scripts/check_org_comments.rb
@@ -8,8 +8,8 @@ module DevOrbit
   module Scripts
     class CheckOrgComments < Thor
       desc "render", "check for new DEV comments on an organization and push them to Orbit"
-      def render
-        client = DevOrbit::Client.new
+      def render(*params)
+        client = DevOrbit::Client.new(historical_import: params[0])
         client.organization_comments
       end
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -16,6 +16,22 @@ RSpec.describe DevOrbit::Client do
     expect(subject).to be_truthy
   end
 
+  it "defaults to false for historical import" do
+    expect(subject.historical_import).to eq(false)
+  end
+
+  it "allows historical import to be defined during initialization" do
+    client = DevOrbit::Client.new(
+      dev_api_key: "12345",
+      dev_username: "test",
+      orbit_api_key: "12345",
+      orbit_workspace: "test",
+      historical_import: true
+    )
+
+    expect(client.historical_import).to eq(true)
+  end
+
   it "initializes with credentials from environment variables" do
     allow(ENV).to receive(:[]).with("DEV_API_KEY").and_return("12345")
     allow(ENV).to receive(:[]).with("DEV_USERNAME").and_return("test")


### PR DESCRIPTION
The integration previously was checking for DEV comments newer than 1 day ago. This PR refactors to look for DEV comments newer than the newest one in the Orbit workspace.

It also adds more helpful output upon finishing the `#comments` execution. The CLI is updated with a new `--historical-import` flag. More tests are added to check for the various cases. README has been updated with more instructions as well.