### PR TITLE
Fix query params path for organization comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,6 @@
 
 - Add pagination for all DEV interactions
 - Dynamically filter what to send to Orbit based on last item of that type in the Orbit workspace
+## [0.5.1] - 2021-07-11
+
+- Fix URL query params path for organization comments

--- a/lib/dev_orbit/dev.rb
+++ b/lib/dev_orbit/dev.rb
@@ -69,7 +69,7 @@ module DevOrbit
         url = URI("https://dev.to/api/articles?username=#{@username}&page=#{page}&per_page=1000") if type == "user"
 
         if type == "organization"
-          url = URI("https://dev.to/api/organizations/#{@organization}/articles&page=#{page}&per_page=1000")
+          url = URI("https://dev.to/api/organizations/#{@organization}/articles?page=#{page}&per_page=1000")
         end
 
         https = Net::HTTP.new(url.host, url.port)
@@ -78,6 +78,8 @@ module DevOrbit
         request = Net::HTTP::Get.new(url)
 
         response = https.request(request)
+
+        break if response.code == "404"
 
         response = JSON.parse(response.body) if DevOrbit::Utils.valid_json?(response.body)
 
@@ -105,6 +107,8 @@ module DevOrbit
         request["api_key"] = @api_key
 
         response = https.request(request)
+
+        break if response.code == "404"
 
         response = JSON.parse(response.body) if DevOrbit::Utils.valid_json?(response.body)
 

--- a/lib/dev_orbit/version.rb
+++ b/lib/dev_orbit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DevOrbit
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
The query params URL path for organization comments was incorrectly formed. In addition, this PR adds breaking out of the collection of API responses from DEV if the API returns a 404.