### PR TITLE
Add User-Agent header for DEV

### DIFF
--- a/lib/dev_orbit/dev.rb
+++ b/lib/dev_orbit/dev.rb
@@ -76,6 +76,7 @@ module DevOrbit
         https.use_ssl = true
 
         request = Net::HTTP::Get.new(url)
+        request["User-Agent"] = "community-ruby-dev-orbit/#{DevOrbit::VERSION}"
 
         response = https.request(request)
 
@@ -105,6 +106,7 @@ module DevOrbit
 
         request = Net::HTTP::Get.new(url)
         request["api_key"] = @api_key
+        request["User-Agent"] = "community-ruby-dev-orbit/#{DevOrbit::VERSION}"
 
         response = https.request(request)
 
@@ -127,6 +129,7 @@ module DevOrbit
       https.use_ssl = true
 
       request = Net::HTTP::Get.new(url)
+      request["User-Agent"] = "community-ruby-dev-orbit/#{DevOrbit::VERSION}"
 
       response = https.request(request)
 


### PR DESCRIPTION
DEV has begun blocking plain Net::HTTP requests in an effort to crack down on bots scraping the site. This can be worked around by setting an appropriate User-Agent header.

See https://github.com/forem/forem/pull/15626

Fixes #22